### PR TITLE
Fix for River Troll Hag cannot get the traits for some hero action tr…

### DIFF
--- a/script/campaign/mod/fix_agent_action_traits.lua
+++ b/script/campaign/mod/fix_agent_action_traits.lua
@@ -1,6 +1,6 @@
 local ACTION_KEY_TO_ACTION = {
 	["wh2_dlc15_agent_action_runesmith_assist_army_replenish_troops"] = "Replenish Troops",
-    ["wh2_dlc15_agent_action_runesmith_hinder_army_assault_unit"] = "Assault Units",
+    ["wh2_dlc15_agent_action_runesmith_hinder_army_assault_unit"] = "Assault Unit",
     ["wh2_dlc15_agent_action_runesmith_hinder_settlement_steal_technology"] = "Steal Technology"
 }
 


### PR DESCRIPTION
…aits

Fix for a fix
wrong trait assigned due to a mistake I made in the ACTION_KEY_TO_ACTION table:
The action is called "Assault Unit", not "Assault Units"