### PR TITLE
Fix for: multiplayer Greenskin Incursions Event while playing as Bret…

### DIFF
--- a/script/campaign/mod/fix_brt_grn_incursion.lua
+++ b/script/campaign/mod/fix_brt_grn_incursion.lua
@@ -1,0 +1,18 @@
+function fix_brt_grn_incursion()
+    if cm:is_multiplayer() then
+        core:add_listener(
+			"Bret_StartCharacterRazedSettlement",
+			"CharacterRazedSettlement",
+			true,
+			function(context) Bret_StartCharacterRazedSettlement(context) end,
+			true
+		)
+		core:add_listener(
+			"Bret_StartCharacterOccupiesSettlement",
+			"GarrisonOccupiedEvent",
+			true,
+			function(context) Bret_StartCharacterRazedSettlement(context) end,
+			true
+        )
+    end
+end


### PR DESCRIPTION
…onnia in a ME Multiplayer does not get removed

Bug:
Listeners responsible for removing the effect are trapped in a "if cm:is_multiplayer() == false then" statement block.

Solution:
Also add these listeners for "cm:is_multiplayer() == true". The function the listeners are calling should be multiplayer compatible.