### PR TITLE
Fix for: Supply line penalties take 1 turn to update

### DIFF
--- a/script/battle/quest_battles/wh2_final_battle/player/high_elves_battle_script.lua
+++ b/script/battle/quest_battles/wh2_final_battle/player/high_elves_battle_script.lua
@@ -1,0 +1,67 @@
+load_script_libraries();
+
+local file_name, file_path = get_file_name_and_path();
+package.path = file_path .. "/?.lua;" .. package.path;
+require("battle_declarations");
+
+loading_screen_key = "wh2_main_final_battle_victory_hef";
+
+speech = {};
+
+if ga_player:are_unit_types_in_army("wh2_main_hef_cha_tyrion_0", "wh2_main_hef_cha_tyrion_1") then
+	speech = {
+		{"Play_wh2_main_qb_hef_tyrion_final_battle_pt_01", "wh2_main_qb_hef_tyrion_final_battle_pt_01"},
+		{"Play_wh2_main_qb_hef_tyrion_final_battle_pt_02", "wh2_main_qb_hef_tyrion_final_battle_pt_02"},
+		{"Play_wh2_main_qb_hef_tyrion_final_battle_pt_03", "wh2_main_qb_hef_tyrion_final_battle_pt_03"},
+		{"Play_wh2_main_qb_hef_tyrion_final_battle_pt_04", "wh2_main_qb_hef_tyrion_final_battle_pt_04"}
+	};
+elseif ga_player:are_unit_types_in_army("wh2_main_hef_cha_teclis_0", "wh2_main_hef_cha_teclis_1", "wh2_dlc15_hef_cha_teclis_2") then
+	speech = {
+		{"Play_wh2_main_qb_hef_teclis_final_battle_pt_01", "wh2_main_qb_hef_teclis_final_battle_pt_01"},
+		{"Play_wh2_main_qb_hef_teclis_final_battle_pt_02", "wh2_main_qb_hef_teclis_final_battle_pt_02"},
+		{"Play_wh2_main_qb_hef_teclis_final_battle_pt_03", "wh2_main_qb_hef_teclis_final_battle_pt_03"},
+		{"Play_wh2_main_qb_hef_teclis_final_battle_pt_04", "wh2_main_qb_hef_teclis_final_battle_pt_04"}
+	};
+elseif ga_player:are_unit_types_in_army("wh2_dlc10_hef_cha_alith_anar_0") then
+	speech = {
+		{"Play_wh2_dlc10_HEF_Alith_Anar_QB_Final_Battle_pt_1", "wh2_dlc10_qb_hef_alith_anar_final_battle_pt_01"},
+		{"Play_wh2_dlc10_HEF_Alith_Anar_QB_Final_Battle_pt_2", "wh2_dlc10_qb_hef_alith_anar_final_battle_pt_02"},
+		{"Play_wh2_dlc10_HEF_Alith_Anar_QB_Final_Battle_pt_3", "wh2_dlc10_qb_hef_alith_anar_final_battle_pt_03"},
+		{"Play_wh2_dlc10_HEF_Alith_Anar_QB_Final_Battle_pt_4", "wh2_dlc10_qb_hef_alith_anar_final_battle_pt_04"}
+	};
+elseif ga_player:are_unit_types_in_army("wh2_dlc10_hef_cha_alarielle_the_radiant_0", "wh2_dlc10_hef_cha_alarielle_the_radiant_1", "wh2_dlc10_hef_cha_alarielle_the_radiant_2", "wh2_dlc10_hef_cha_alarielle_the_radiant_3") then
+	speech = {
+		{"Play_wh2_dlc10_HEF_Alarielle_QB_Final_Battle_pt_01", "wh2_dlc10_qb_hef_alarielle_final_battle_pt_01"},
+		{"Play_wh2_dlc10_HEF_Alarielle_QB_Final_Battle_pt_02", "wh2_dlc10_qb_hef_alarielle_final_battle_pt_02"},
+		{"Play_wh2_dlc10_HEF_Alarielle_QB_Final_Battle_pt_03", "wh2_dlc10_qb_hef_alarielle_final_battle_pt_03"},
+		{"Play_wh2_dlc10_HEF_Alarielle_QB_Final_Battle_pt_04", "wh2_dlc10_qb_hef_alarielle_final_battle_pt_04"}
+	};	
+
+elseif ga_player:are_unit_types_in_army("wh2_dlc15_hef_cha_imrik_0", "wh2_dlc15_hef_cha_imrik_1", "wh2_dlc15_hef_cha_imrik_2") then
+	speech = {
+		{"Play_wh2_dlc15_HEF_Imrik_final_battle_pt_01", "wh2_dlc15_HEF_Imrik_final_battle_pt_01"},
+		{"Play_wh2_dlc15_HEF_Imrik_final_battle_pt_02", "wh2_dlc15_HEF_Imrik_final_battle_pt_02"},
+		{"Play_wh2_dlc15_HEF_Imrik_final_battle_pt_03", "wh2_dlc15_HEF_Imrik_final_battle_pt_03"},
+		{"Play_wh2_dlc15_HEF_Imrik_final_battle_pt_04", "wh2_dlc15_HEF_Imrik_final_battle_pt_04"}
+	};	
+end;
+
+--------HORNED RAT VO----------
+horned_rat_vo = {
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_01"),
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_02"),
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_03"),
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_04"),
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_05"),
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_06"),
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_07"),
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_08"),
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_09"),
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_10"),
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_11"),
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_12"),
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_13"),
+	new_sfx("Play_FinalQ_Horned_Rat_HEF_14")
+};
+
+require("battle_core");

--- a/script/campaign/mod/fix_supply_lines.lua
+++ b/script/campaign/mod/fix_supply_lines.lua
@@ -1,0 +1,84 @@
+function fix_supply_lines()
+    -- apply the effect bundles every time a player's general "dies"
+    core:add_listener(
+        "fix_supply_lines_character_convalesced_or_killed",
+        "CharacterConvalescedOrKilled",
+        function(context)
+            return context:character():character_type("general") and upkeep_penalty_condition(context:character():faction())
+		end,
+        function(context)
+            local faction = context:character():faction()
+            cm:callback(function() 
+                apply_upkeep_penalty(faction)
+            end, 0.1) 
+        end,
+        true
+    )
+    core:remove_listener("disband_player_army_count")
+end
+
+function player_army_count_listener()
+	-- apply the effect bundles every time the player turn starts
+	core:add_listener(
+		"player_army_turn_start_listener",
+		"FactionTurnStart",
+		function(context)
+			return upkeep_penalty_condition(context:faction())
+		end,
+        function(context)
+            local faction = context:faction()
+            cm:callback(function() 
+                apply_upkeep_penalty(faction)
+            end, 0.1) 
+		end,
+		true
+	)
+
+	-- apply the effect bundles every time the player creates a new force
+	core:add_listener(
+		"player_army_created_listener",
+		"MilitaryForceCreated",
+		function(context)
+			return upkeep_penalty_condition(context:military_force_created():faction())
+		end,
+        function(context)
+            local faction = context:military_force_created():faction()
+            cm:callback(function() 
+                apply_upkeep_penalty(faction)
+            end, 0.1) 
+		end,
+		true
+	)
+	
+	-- apply the effect bundles every time the player confederates
+	core:add_listener(
+		"confederation_player_army_count_listener",
+		"FactionJoinsConfederation",
+		function(context)
+			return upkeep_penalty_condition(context:confederation())
+		end,
+        function(context)
+            local faction = context:confederation()
+            cm:callback(function() 
+                apply_upkeep_penalty(faction)
+            end, 0.1) 
+		end,
+		true
+	)
+
+	--core:add_listener(
+	--	"disband_player_army_count",
+	--	"UnitDisbanded",
+	--	function(context)
+	--		local unit = context:unit()
+	--		local has_unit_commander = unit:has_unit_commander()
+    --
+	--		return has_unit_commander == true and upkeep_penalty_condition(unit:faction())
+	--	end,
+	--	function(context)
+	--		local unit = context:unit()
+	--		apply_upkeep_penalty(unit:faction())
+	--	end,
+	--	true
+	--)
+end


### PR DESCRIPTION
Bug:
Supply line penalties take 1 turn to update if the a force was killed or disbanded.

Solution:
Listen for CharacterConvalescedOrKilled and execute the apply_upkeep_penalty function if the killed character is a general type and delay the the execution of the apply_upkeep_penalty to make sure the recently killed force is properly dead.