### PR TITLE
Fix for sarthorael spawns without units when the player is chaos

### DIFF
--- a/script/campaign/main_warhammer/mod/fix_ci_ram.lua
+++ b/script/campaign/main_warhammer/mod/fix_ci_ram.lua
@@ -1,0 +1,1 @@
+ci_setup_armies()


### PR DESCRIPTION
Bug:
random_army_manager isn't being set up correctly.

Solution:
Execute the ci_setup_armies function to set up the ram.