### PR TITLE
Fix for Ghoritch/Coeddil spawning for their original faction instead …

### DIFF
--- a/script/_lib/mod/fix_ghoritch.lua
+++ b/script/_lib/mod/fix_ghoritch.lua
@@ -1,9 +1,7 @@
-local throt_faction_key = "wh2_main_skv_clan_moulder";
-
 function add_throt_unlock_ghoritch_listeners()
 	out("#### Adding Throt Unlock Ghoritch Listeners ####");
-    local throt_interface = cm:model():world():faction_by_key(throt_faction_key);
-    if throt_interface:is_null_interface() == false then
+    --local throt_interface = cm:model():world():faction_by_key(throt_faction_key);
+    --if throt_interface:is_null_interface() == false then
         core:add_listener(
             "Ghoritch_MissionSucceeded",
             "MissionSucceeded",
@@ -11,7 +9,7 @@ function add_throt_unlock_ghoritch_listeners()
                 return context:mission():mission_record_key():find("whip_of_domination_stage_4");
             end,
             function(context)
-                local throt_faction_cqi = throt_interface:command_queue_index();
+                local throt_faction_cqi = context:faction():command_queue_index();
                 local throt = context:faction():faction_leader();
                 local throt_cqi = throt:command_queue_index();
                 
@@ -20,7 +18,7 @@ function add_throt_unlock_ghoritch_listeners()
                 -- number The cqi of the target character.
                 -- boolean Force agent to spawn even if invalid.
                 cm:spawn_unique_agent_at_character(throt_faction_cqi, "wh2_dlc16_skv_ghoritch", throt_cqi, false);
-                cm:trigger_incident(throt_faction_key, "wh2_dlc16_incident_skv_ghoritch_arrives", true, false);
+                cm:trigger_incident(context:faction():name(), "wh2_dlc16_incident_skv_ghoritch_arrives", true, false);
             end,
             false
         );
@@ -34,7 +32,7 @@ function add_throt_unlock_ghoritch_listeners()
             end,
             function(context)
                 -- ideally we would care for the edge cases where throt is confederated before this happens so ghoritch appears regardless, but at rank 5 the odds are very low
-                local throt_faction_cqi = throt_interface:command_queue_index();
+                local throt_faction_cqi = context:character():faction():command_queue_index();
                 -- number Faction cqi
                 -- string Agent record key from the unique_agents table
                 -- boolean Force agent to spawn even if invalid.
@@ -44,5 +42,5 @@ function add_throt_unlock_ghoritch_listeners()
             end,
             false
         );
-    end
+    --end
 end


### PR DESCRIPTION
…of the Confederator

When their original faction gets revived Ghoritch/Coeddil might spawn for them instead of the faction that's currently holding Drycha/Throt and actually leveled them or succeeded in the mission to spawn therm.